### PR TITLE
fix config for current version of webpack

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,7 +8,7 @@ module.exports = {
 	},
 	module: {
 	  loaders: [
-			{ test: /\.jsx?$/, exclude: /(node_modules|bower_components)/, loader: 'babel' },
+			{ test: /\.jsx?$/, exclude: /(node_modules|bower_components)/, loader: 'babel-loader' },
 			{ test: /\.css$/, loader: 'style-loader!css-loader' },
 			{ test: /\.eot(\?v=\d+\.\d+\.\d+)?$/, loader: "file" },
 			{ test: /\.(woff|woff2)$/, loader:"url?prefix=font/&limit=5000" },


### PR DESCRIPTION
Solves this error:

BREAKING CHANGE: It's no longer allowed to omit the '-loader' suffix when using loaders.
You need to specify 'babel-loader' instead of 'babel',
see https://webpack.js.org/guides/migrating/#automatic-loader-module-name-extension-removed
 @ multi (webpack)-dev-server/client?http://localhost:8083 ./app/javascripts/app.js